### PR TITLE
Add Glide for managing vendored dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 benchmark_*.txt
 vasco
 build
+vendor

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,32 @@
+hash: 4368ea2e8fc71a546d8b565deb27df3431153b722b888bcc8bd8959aa2a28a9f
+updated: 2016-08-17T22:23:10.385173577-04:00
+imports:
+- name: github.com/AchievementNetwork/go-util
+  version: 583c8a97bfc784149aa192d564cbc2e194a4af11
+  subpackages:
+  - util
+- name: github.com/AchievementNetwork/stringset
+  version: d4ea4c4c14bdfc47fd4b19fc88133ee01db8ca80
+- name: github.com/AchievementNetwork/vasco
+  version: 0b259d5add07a9dfc902d9e93a96e563a02cb2ef
+  subpackages:
+  - cache
+  - registry
+- name: github.com/emicklei/go-restful
+  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
+  subpackages:
+  - swagger
+  - log
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,21 @@
+package: github.com/achievementnetwork/vasco
+import:
+- package: github.com/AchievementNetwork/go-util
+  version: ~1.0.0
+  subpackages:
+  - util
+- package: github.com/AchievementNetwork/stringset
+- package: github.com/AchievementNetwork/vasco
+  version: ~0.16.11
+  subpackages:
+  - cache
+  - registry
+- package: github.com/emicklei/go-restful
+  version: ~1.2.0
+  subpackages:
+  - swagger
+testImport:
+- package: github.com/stretchr/testify
+  version: ~1.1.3
+  subpackages:
+  - assert


### PR DESCRIPTION
There is a failure not relating to dependency management in this:

```
$ go test -v -race $(glide novendor)
# github.com/achievementnetwork/vasco/registry
registry/registry_test.go:40: not enough arguments in call to NewRegistry
# github.com/achievementnetwork/vasco
./vasco_test.go:14: not enough arguments in call to NewVasco
 === RUN   TestTest
--- PASS: TestTest (0.00s)
       	cache_test.go:31: Now testing *cache.LocalCache
=== RUN   TestBasicSetGet
--- PASS: TestBasicSetGet (0.00s)
=== RUN   TestOverwritingKey
--- PASS: TestOverwritingKey (0.00s)
=== RUN   TestGetFail
--- PASS: TestGetFail (0.00s)
=== RUN   TestDelete
--- PASS: TestDelete (0.00s)
=== RUN   TestMultipleKeys
--- PASS: TestMultipleKeys (0.00s)
=== RUN   TestExpire
--- PASS: TestExpire (2.19s)
=== RUN   TestSAddSGet
--- PASS: TestSAddSGet (0.00s)
=== RUN   TestMultipleAdd
--- PASS: TestMultipleAdd (0.00s)
=== RUN   TestSCount
--- PASS: TestSCount (0.00s)
=== RUN   TestSRemove
--- PASS: TestSRemove (0.00s)
=== RUN   TestSRandom
--- PASS: TestSRandom (0.00s)
=== RUN   TestZAddZRange
--- PASS: TestZAddZRange (0.00s)
=== RUN   TestZAddAgain
--- PASS: TestZAddAgain (0.00s)
PASS
ok     	github.com/achievementnetwork/vasco/cache      	3.219s
FAIL   	github.com/achievementnetwork/vasco/registry [build failed]
FAIL   	github.com/achievementnetwork/vasco [build failed]
```