### PR TITLE
No pretty json by default

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -129,7 +129,7 @@ func (v *Vasco) statusOptions(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (v *Vasco) statusDetail(rw http.ResponseWriter, req *http.Request) {
-	util.WriteJSONPretty(rw, v.lastStatus)
+	util.WriteJSON(rw, v.lastStatus)
 	v.refreshStatusSoon()
 }
 


### PR DESCRIPTION
The `/status/detail` endpoint is, shall we say, "overstepping" by prettifying it's JSON output--which was the source of great pain for me when trying to consume and parse this payload by another service. 

Here, we just write it out without formatting it. Let the receiving in make it pretty if it so wishes.