### PR TITLE
Kjq/fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VASCO_STATUS ?= 8082
 REDIS_ADDR ?= localhost:6379
 MINPORT ?= 8100
 MAXPORT ?= 9900
-EXPECTED_SERVICES ?= config assess item passage pdf sas staticserver stdmirror stdtag user assessapi learnm
+EXPECTED_SERVICES ?= assess item passage pdf sas staticserver stdmirror stdtag user assessapi learnm
 STATUS_TIME ?= 60
 DISCOVERY_EXPIRATION ?= 3600
 STATIC_PATH ?= /static
@@ -64,7 +64,7 @@ ecs-register-task:
 		--port-mappings="$(VASCO_PROXY):$(VASCO_PROXY),$(VASCO_REGISTRY):$(VASCO_REGISTRY),$(VASCO_STATUS):$(VASCO_STATUS)" \
 		--ecs-task-memory=$(ECS_TASK_MEMORY) \
 		--envars="$(ENVARS)"
- 
+
 ecs-first-deploy: ecr-image ecs-create-service
 	@echo "First Deploy Complete"
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ _Generates detailed status information._
 
 
 
+_**Parameters:**_
+
+Name | Kind | Description | DataType
+---- | ---- | ----------- | --------
+ wait | Query | if non-empty, wait for current status from all services before returning result. | string
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ _**Reads:**_
 
 _**Produces:**_ `[application/json]`
 
-Hash value that will be used to refresh or unregister the server later.  Something like:
-
-```json
-        "a11807a8b35440438193b436e249a8e7"
-```
 
 _**Writes:**_
 ```json
@@ -264,6 +259,8 @@ The status portion of Vasco reports aggregated status statistics.
 
 * [statusGeneral](#statusgeneral)
 
+* [statusStrict](#statusstrict)
+
 * [statusDetail](#statusdetail)
 
 * [statusSummary](#statussummary)
@@ -309,6 +306,30 @@ _**Error returns:**_
 Code | Meaning
 ---- | --------
  500 | There is a major service problem.
+
+
+
+---
+## statusStrict
+
+### `GET /status/strict`
+
+_Returns 200 only if all expected servers are up._
+
+
+
+
+
+
+
+
+
+
+_**Error returns:**_
+
+Code | Meaning
+---- | --------
+ 500 | At least one server is down.
 
 
 

--- a/loopTimer.go
+++ b/loopTimer.go
@@ -1,0 +1,48 @@
+package main
+
+// LoopTimer is a timer that keeps re-starting itself after the LoopTime.
+import "time"
+
+// Each time it restarts, it calls the LoopFunc in its own goroutine.
+// You can short-circuit the loop count by calling AtMost to set the current loop
+// to a (possibly) shorter time. It will then return to its normal loop time.
+// The granularity (precision) of the timer is controlled by TickTime.
+type LoopTimer struct {
+	TickTime time.Duration
+	LoopTime time.Duration
+	LoopFunc func()
+	t        *time.Timer
+	nextLoop time.Time
+}
+
+func NewLoopTimer(tickTime, loopTime time.Duration, loopFunc func()) *LoopTimer {
+	t := &LoopTimer{
+		TickTime: tickTime,
+		LoopTime: loopTime,
+		LoopFunc: loopFunc,
+		nextLoop: time.Now().Add(loopTime),
+	}
+	t.t = time.AfterFunc(tickTime, t.tickFunc)
+	return t
+}
+
+// TickFunc is called after every tick; if the current time is after the nextLoop
+// time, we call the LoopFunc() and add the LoopTime to the nextLoop time. Note this is
+// NOT added to the current time -- this ensures that on average we'll be no more than
+// one TickTime away from the loopTime (as long as no one calls AtMost).
+func (l *LoopTimer) tickFunc() {
+	if time.Now().After(l.nextLoop) {
+		go l.LoopFunc()
+		l.nextLoop = l.nextLoop.Add(l.LoopTime)
+	}
+	l.t = time.AfterFunc(l.TickTime, l.tickFunc)
+}
+
+// AtMost specifies that the timer should fire after at most the specified
+// duration (this is how you short-circuit a count)
+func (l *LoopTimer) AtMost(d time.Duration) {
+	maxt := time.Now().Add(d)
+	if l.nextLoop.After(maxt) {
+		l.nextLoop = maxt
+	}
+}

--- a/vasco.go
+++ b/vasco.go
@@ -30,7 +30,7 @@ type Vasco struct {
 	cache          cache.Cache
 	registry       *registry.Registry
 	lastStatus     registry.StatusBlock
-	statusTimer    *time.Timer
+	statusTimer    *LoopTimer
 	allowedMethods []string
 	allowedHeaders []string
 	allowedOrigins []string
@@ -222,6 +222,7 @@ func (v *Vasco) CreateStatusService() *bone.Mux {
 
 	svc.Route(svc.GET("/status/detail").To(v.statusDetail).
 		Doc("Generates detailed status information.").
+		Param(boneful.QueryParameter("wait", "if non-empty, wait for current status from all services before returning result.").DataType("string").Required(false)).
 		Produces("application/json").
 		Returns(http.StatusInternalServerError, "There is a major service problem.", nil).
 		Operation("statusDetail").
@@ -337,7 +338,9 @@ func main() {
 	statusMux := v.CreateStatusService()
 
 	// wait a few seconds to let clients find us and then start requesting and watching status
-	v.statusTimer = time.AfterFunc(15*time.Second, v.statusUpdate)
+	statusTime, _ := strconv.Atoi(getEnvWithDefault("STATUS_TIME", "60"))
+	v.statusTimer = NewLoopTimer(250*time.Millisecond, time.Duration(statusTime)*time.Second, v.statusUpdate)
+	v.statusTimer.AtMost(10 * time.Second)
 
 	serverErrors := make(chan error)
 

--- a/vasco.go
+++ b/vasco.go
@@ -215,6 +215,11 @@ func (v *Vasco) CreateStatusService() *bone.Mux {
 		Returns(http.StatusInternalServerError, "There is a major service problem.", nil).
 		Operation("statusGeneral"))
 
+	svc.Route(svc.GET("/status/strict").To(v.statusStrict).
+		Doc("Returns 200 only if all expected servers are up.").
+		Returns(http.StatusInternalServerError, "At least one server is down.", nil).
+		Operation("statusStrict"))
+
 	svc.Route(svc.GET("/status/detail").To(v.statusDetail).
 		Doc("Generates detailed status information.").
 		Produces("application/json").


### PR DESCRIPTION
This PR combines a couple of improvements to Vasco. It might be best to review individual commits.

* Adds a status/strict endpoint to return a non-200 status if any of the expected services are down. (Normal status always returns 200.) This is to allow a monitoring system to watch for any service problems while still allowing debug through the normal status ports. Also updates docs.

* Removes the "config" expected service, which was removed as an actual service a long time ago.

* The old timer behavior was clunky because Go's timer is minimal. Create
a LoopTimer that has our desired behavior. Also allow status/detail to
wait for a current update.

* Update documentation