### PR TITLE
Preserve the disabled flag in the cache

### DIFF
--- a/registry/registration.go
+++ b/registry/registration.go
@@ -30,7 +30,7 @@ type Registration struct {
 	Pattern  string `json:"pattern"`
 	Weight   int    `json:"weight,omitempty"`
 	Stat     Status `json:"status,omitempty"`
-	disabled bool
+	Disabled bool   `json:"disabled"`
 	hash     string
 	regex    *regexp.Regexp
 	url      *url.URL

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -147,7 +147,7 @@ func (r *Registry) DetailedStatus() StatusBlock {
 		item["Name"] = reg.Name
 		item["Address"] = reg.Address
 		item["Port"] = ""
-		item["Disabled"] = reg.Disabled
+		item["disabled"] = reg.Disabled
 		hs := strings.Split(u.Host, ":")
 		if len(hs) == 2 {
 			item["Port"] = hs[1]
@@ -233,7 +233,7 @@ func (r *Registry) getAllRegistrations() []*Registration {
 			removes = append(removes, hash)
 		} else {
 			reg := NewRegFromJSON(regtext)
-			// don't consider Disabled registrations
+			// don't consider disabled registrations
 			if !reg.Disabled {
 				results = append(results, reg)
 			}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -125,8 +125,8 @@ func (r *Registry) DetailedStatus() StatusBlock {
 		if err != nil {
 			item["Error"] = fmt.Sprintf("GET from %s failed.", u.String())
 			item["StatusCode"] = http.StatusServiceUnavailable
-			if !reg.disabled {
-				reg.disabled = true
+			if !reg.Disabled {
+				reg.Disabled = true
 				r.c.Set(reg.Hash(), reg.String())
 				// if the service becomes unavailable, expire it in 5 minutes
 				r.c.Expire(reg.Hash(), 300)
@@ -138,8 +138,8 @@ func (r *Registry) DetailedStatus() StatusBlock {
 				item["StatusBody"] = string(body)
 			}
 			item["StatusCode"] = result.StatusCode
-			if reg.disabled {
-				reg.disabled = false
+			if reg.Disabled {
+				reg.Disabled = false
 				r.c.Set(reg.Hash(), reg.String())
 				r.c.Expire(reg.Hash(), r.Timeout+2)
 			}
@@ -147,7 +147,7 @@ func (r *Registry) DetailedStatus() StatusBlock {
 		item["Name"] = reg.Name
 		item["Address"] = reg.Address
 		item["Port"] = ""
-		item["disabled"] = reg.disabled
+		item["Disabled"] = reg.Disabled
 		hs := strings.Split(u.Host, ":")
 		if len(hs) == 2 {
 			item["Port"] = hs[1]
@@ -233,8 +233,8 @@ func (r *Registry) getAllRegistrations() []*Registration {
 			removes = append(removes, hash)
 		} else {
 			reg := NewRegFromJSON(regtext)
-			// don't consider disabled registrations
-			if !reg.disabled {
+			// don't consider Disabled registrations
+			if !reg.Disabled {
 				results = append(results, reg)
 			}
 		}


### PR DESCRIPTION
The disabled flag was never saved to the cache or restored from it, so it was very short-lived. This PR saves the flag so that we won't route to disabled paths.